### PR TITLE
表のセルに対するテキストの割り当てロジックの変更

### DIFF
--- a/src/yomitoku/cli/main.py
+++ b/src/yomitoku/cli/main.py
@@ -244,16 +244,16 @@ def main():
     if path.is_dir():
         all_files = [f for f in path.rglob("*") if f.is_file()]
         for f in all_files:
-            # try:
-            start = time.time()
-            file_path = Path(f)
-            logger.info(f"Processing file: {file_path}")
-            print("aaa", file_path)
-            process_single_file(args, analyzer, file_path, format)
-            end = time.time()
-            logger.info(f"Total Processing time: {end-start:.2f} sec")
-            # except Exception:
-            #   continue
+            try:
+                start = time.time()
+                file_path = Path(f)
+                logger.info(f"Processing file: {file_path}")
+                print("aaa", file_path)
+                process_single_file(args, analyzer, file_path, format)
+                end = time.time()
+                logger.info(f"Total Processing time: {end-start:.2f} sec")
+            except Exception:
+                continue
     else:
         start = time.time()
         logger.info(f"Processing file: {path}")

--- a/src/yomitoku/cli/main.py
+++ b/src/yomitoku/cli/main.py
@@ -28,7 +28,6 @@ def process_single_file(args, analyzer, path, format):
 
     for page, img in enumerate(imgs):
         results, ocr, layout = analyzer(img)
-
         dirname = path.parent.name
         filename = path.stem
 
@@ -245,15 +244,16 @@ def main():
     if path.is_dir():
         all_files = [f for f in path.rglob("*") if f.is_file()]
         for f in all_files:
-            try:
-                start = time.time()
-                file_path = Path(f)
-                logger.info(f"Processing file: {file_path}")
-                process_single_file(args, analyzer, file_path, format)
-                end = time.time()
-                logger.info(f"Total Processing time: {end-start:.2f} sec")
-            except Exception:
-                continue
+            # try:
+            start = time.time()
+            file_path = Path(f)
+            logger.info(f"Processing file: {file_path}")
+            print("aaa", file_path)
+            process_single_file(args, analyzer, file_path, format)
+            end = time.time()
+            logger.info(f"Total Processing time: {end-start:.2f} sec")
+            # except Exception:
+            #   continue
     else:
         start = time.time()
         logger.info(f"Processing file: {path}")

--- a/src/yomitoku/cli/main.py
+++ b/src/yomitoku/cli/main.py
@@ -248,7 +248,6 @@ def main():
                 start = time.time()
                 file_path = Path(f)
                 logger.info(f"Processing file: {file_path}")
-                print("aaa", file_path)
                 process_single_file(args, analyzer, file_path, format)
                 end = time.time()
                 logger.info(f"Total Processing time: {end-start:.2f} sec")

--- a/src/yomitoku/document_analyzer.py
+++ b/src/yomitoku/document_analyzer.py
@@ -77,7 +77,7 @@ def extract_paragraph_within_figure(paragraphs, figures):
         figure = {"box": figure.box, "order": 0}
         contained_paragraphs = []
         for i, paragraph in enumerate(paragraphs):
-            if is_contained(figure["box"], paragraph.box, threshold=0.7):
+            if is_contained(figure["box"], paragraph.box, threshold=0.7)[0]:
                 contained_paragraphs.append(paragraph)
                 check_list[i] = True
 
@@ -92,14 +92,14 @@ def extract_paragraph_within_figure(paragraphs, figures):
     return new_figures, check_list
 
 
-def extract_words_within_element(pred_words, element):
+def extract_words_within_element(pred_words, element, join=True):
     contained_words = []
     word_sum_width = 0
     word_sum_height = 0
     check_list = [False] * len(pred_words)
     for i, word in enumerate(pred_words):
         word_box = quad_to_xyxy(word.points)
-        if is_contained(element.box, word_box, threshold=0.5):
+        if is_contained(element.box, word_box, threshold=0.5)[0]:
             contained_words.append(word)
             word_sum_width += word_box[2] - word_box[0]
             word_sum_height += word_box[3] - word_box[1]
@@ -128,7 +128,9 @@ def extract_words_within_element(pred_words, element):
             reverse=True,
         )
 
+    # if join:
     contained_words = "\n".join([content.content for content in contained_words])
+
     return (contained_words, element_direction, check_list)
 
 
@@ -187,6 +189,56 @@ class DocumentAnalyzer:
         paragraphs = []
         check_list = [False] * len(ocr_res.words)
         for table in layout_res.tables:
+            #    table_words, _, flags = extract_words_within_element(
+            #        ocr_res.words, table, join=False
+            #    )
+            #
+            #    check_list = combine_flags(check_list, flags)
+            #
+            #    intersections = [[0 for cell in table.cells] for word in table_words]
+            #    print(intersections)
+            #    print(len(table.cells))
+            #
+            #    for i, word in enumerate(table_words):
+            #        word_box = quad_to_xyxy(word.points)
+            #        for j, cell in enumerate(table.cells):
+            #            intersections[i][j] = is_contained(word_box, cell.box)[1]
+            #
+            #    print(intersections)
+            #    allocated_cell = [cells.index(max(cells)) for cells in intersections]
+            #
+            #    # print(allocated_cell)
+            #
+            #    for j, cell in enumerate(table.cells):
+            #        contained_words = [
+            #            table_words[i] for i, idx in enumerate(allocated_cell) if idx == j
+            #        ]
+            #
+            #        word_direction = [word.direction for word in contained_words]
+            #        cnt_horizontal = word_direction.count("horizontal")
+            #        cnt_vertical = word_direction.count("vertical")
+            #
+            #        element_direction = (
+            #            "horizontal" if cnt_horizontal > cnt_vertical else "vertical"
+            #        )
+            #        if element_direction == "horizontal":
+            #            contained_words = sorted(
+            #                contained_words,
+            #                key=lambda x: (sum([p[1] for p in x.points]) / 4),
+            #            )
+            #        else:
+            #            contained_words = sorted(
+            #                contained_words,
+            #                key=lambda x: (sum([p[0] for p in x.points]) / 4),
+            #                reverse=True,
+            #            )
+            #
+            #        contained_words = "\n".join(
+            #            [content.content for content in contained_words]
+            #        )
+            #
+            #        cell.contents = contained_words
+
             for cell in table.cells:
                 words, direction, flags = extract_words_within_element(
                     ocr_res.words, cell

--- a/src/yomitoku/document_analyzer.py
+++ b/src/yomitoku/document_analyzer.py
@@ -209,7 +209,7 @@ class DocumentAnalyzer:
             )
 
         # self.ocr = OCR(configs=default_configs["ocr"])
-        self.tect_detector = TextDetector(
+        self.text_detector = TextDetector(
             **default_configs["ocr"]["text_detector"],
         )
         self.text_recognizer = TextRecognizer(
@@ -450,7 +450,7 @@ class DocumentAnalyzer:
             loop = asyncio.get_running_loop()
             tasks = [
                 # loop.run_in_executor(executor, self.ocr, img),
-                loop.run_in_executor(executor, self.tect_detector, img),
+                loop.run_in_executor(executor, self.text_detector, img),
                 loop.run_in_executor(executor, self.layout, img),
             ]
 

--- a/src/yomitoku/ocr.py
+++ b/src/yomitoku/ocr.py
@@ -16,8 +16,8 @@ class WordPrediction(BaseSchema):
     )
     content: str
     direction: str
-    det_score: float
     rec_score: float
+    det_score: float
 
 
 class OCRSchema(BaseSchema):

--- a/src/yomitoku/ocr.py
+++ b/src/yomitoku/ocr.py
@@ -24,6 +24,27 @@ class OCRSchema(BaseSchema):
     words: List[WordPrediction]
 
 
+def ocr_aggregate(det_outputs, rec_outputs):
+    words = []
+    for points, det_score, pred, rec_score, direction in zip(
+        det_outputs.points,
+        det_outputs.scores,
+        rec_outputs.contents,
+        rec_outputs.scores,
+        rec_outputs.directions,
+    ):
+        words.append(
+            {
+                "points": points,
+                "content": pred,
+                "direction": direction,
+                "det_score": det_score,
+                "rec_score": rec_score,
+            }
+        )
+    return words
+
+
 class OCR:
     def __init__(self, configs={}, device="cuda", visualize=False):
         text_detector_kwargs = {
@@ -48,26 +69,6 @@ class OCR:
         self.detector = TextDetector(**text_detector_kwargs)
         self.recognizer = TextRecognizer(**text_recognizer_kwargs)
 
-    def aggregate(self, det_outputs, rec_outputs):
-        words = []
-        for points, det_score, pred, rec_score, direction in zip(
-            det_outputs.points,
-            det_outputs.scores,
-            rec_outputs.contents,
-            rec_outputs.scores,
-            rec_outputs.directions,
-        ):
-            words.append(
-                {
-                    "points": points,
-                    "content": pred,
-                    "direction": direction,
-                    "det_score": det_score,
-                    "rec_score": rec_score,
-                }
-            )
-        return words
-
     def __call__(self, img):
         """_summary_
 
@@ -78,6 +79,6 @@ class OCR:
         det_outputs, vis = self.detector(img)
         rec_outputs, vis = self.recognizer(img, det_outputs.points, vis=vis)
 
-        outputs = {"words": self.aggregate(det_outputs, rec_outputs)}
+        outputs = {"words": ocr_aggregate(det_outputs, rec_outputs)}
         results = OCRSchema(**outputs)
         return results, vis

--- a/src/yomitoku/table_structure_recognizer.py
+++ b/src/yomitoku/table_structure_recognizer.py
@@ -297,7 +297,9 @@ class TableStructureRecognizer(BaseModule):
                     pred = self.model(data["tensor"])
 
             table = self.postprocess(pred, data)
-            outputs.append(table)
+
+            if table.n_row > 0 and table.n_col > 0:
+                outputs.append(table)
 
         if vis is None and self.visualize:
             vis = img.copy()

--- a/src/yomitoku/text_detector.py
+++ b/src/yomitoku/text_detector.py
@@ -143,9 +143,9 @@ class TextDetector(BaseModule):
         vis = None
         if self.visualize:
             vis = det_visualizer(
-                preds,
                 img,
                 quads,
+                preds=preds,
                 vis_heatmap=self._cfg.visualize.heatmap,
                 line_color=tuple(self._cfg.visualize.color[::-1]),
             )

--- a/src/yomitoku/utils/misc.py
+++ b/src/yomitoku/utils/misc.py
@@ -12,7 +12,7 @@ def filter_by_flag(elements, flags):
 def calc_overlap_ratio(rect_a, rect_b):
     intersection = calc_intersection(rect_a, rect_b)
     if intersection is None:
-        return 0
+        return 0, None
 
     ix1, iy1, ix2, iy2 = intersection
 
@@ -24,7 +24,7 @@ def calc_overlap_ratio(rect_a, rect_b):
     overlap_area = overlap_width * overlap_height
 
     overlap_ratio = overlap_area / b_area
-    return overlap_ratio
+    return overlap_ratio, intersection
 
 
 def is_contained(rect_a, rect_b, threshold=0.8):
@@ -41,7 +41,7 @@ def is_contained(rect_a, rect_b, threshold=0.8):
         bool: 矩形Bが矩形Aに含まれる場合True
     """
 
-    overlap_ratio = calc_overlap_ratio(rect_a, rect_b)
+    overlap_ratio, _ = calc_overlap_ratio(rect_a, rect_b)
 
     if overlap_ratio > threshold:
         return True

--- a/src/yomitoku/utils/misc.py
+++ b/src/yomitoku/utils/misc.py
@@ -9,6 +9,24 @@ def filter_by_flag(elements, flags):
     return [element for element, flag in zip(elements, flags) if flag]
 
 
+def calc_overlap_ratio(rect_a, rect_b):
+    intersection = calc_intersection(rect_a, rect_b)
+    if intersection is None:
+        return 0
+
+    ix1, iy1, ix2, iy2 = intersection
+
+    overlap_width = ix2 - ix1
+    overlap_height = iy2 - iy1
+    bx1, by1, bx2, by2 = rect_b
+
+    b_area = (bx2 - bx1) * (by2 - by1)
+    overlap_area = overlap_width * overlap_height
+
+    overlap_ratio = overlap_area / b_area
+    return overlap_ratio
+
+
 def is_contained(rect_a, rect_b, threshold=0.8):
     """二つの矩形A, Bが与えられたとき、矩形Bが矩形Aに含まれるかどうかを判定する。
     ずれを許容するため、重複率求め、thresholdを超える場合にTrueを返す。
@@ -23,25 +41,12 @@ def is_contained(rect_a, rect_b, threshold=0.8):
         bool: 矩形Bが矩形Aに含まれる場合True
     """
 
-    intersection = calc_intersection(rect_a, rect_b)
-    if intersection is None:
-        return False, 0
-
-    ix1, iy1, ix2, iy2 = intersection
-
-    overlap_width = ix2 - ix1
-    overlap_height = iy2 - iy1
-    bx1, by1, bx2, by2 = rect_b
-
-    b_area = (bx2 - bx1) * (by2 - by1)
-    overlap_area = overlap_width * overlap_height
-
-    overlap_ratio = overlap_area / b_area
+    overlap_ratio = calc_overlap_ratio(rect_a, rect_b)
 
     if overlap_ratio > threshold:
-        return True, overlap_ratio
+        return True
 
-    return False, overlap_ratio
+    return False
 
 
 def calc_intersection(rect_a, rect_b):

--- a/src/yomitoku/utils/misc.py
+++ b/src/yomitoku/utils/misc.py
@@ -25,7 +25,7 @@ def is_contained(rect_a, rect_b, threshold=0.8):
 
     intersection = calc_intersection(rect_a, rect_b)
     if intersection is None:
-        return False
+        return False, 0
 
     ix1, iy1, ix2, iy2 = intersection
 
@@ -36,10 +36,12 @@ def is_contained(rect_a, rect_b, threshold=0.8):
     b_area = (bx2 - bx1) * (by2 - by1)
     overlap_area = overlap_width * overlap_height
 
-    if overlap_area / b_area > threshold:
-        return True
+    overlap_ratio = overlap_area / b_area
 
-    return False
+    if overlap_ratio > threshold:
+        return True, overlap_ratio
+
+    return False, overlap_ratio
 
 
 def calc_intersection(rect_a, rect_b):

--- a/src/yomitoku/utils/visualizer.py
+++ b/src/yomitoku/utils/visualizer.py
@@ -66,14 +66,14 @@ def reading_order_visualizer(
     return out
 
 
-def det_visualizer(preds, img, quads, vis_heatmap=False, line_color=(0, 255, 0)):
-    preds = preds["binary"][0]
-    binary = preds.detach().cpu().numpy()
+def det_visualizer(img, quads, preds=None, vis_heatmap=False, line_color=(0, 255, 0)):
     out = img.copy()
     h, w = out.shape[:2]
-    binary = binary.squeeze(0)
-    binary = (binary * 255).astype(np.uint8)
     if vis_heatmap:
+        preds = preds["binary"][0]
+        binary = preds.detach().cpu().numpy()
+        binary = binary.squeeze(0)
+        binary = (binary * 255).astype(np.uint8)
         binary = cv2.resize(binary, (w, h), interpolation=cv2.INTER_LINEAR)
         heatmap = cv2.applyColorMap(binary, cv2.COLORMAP_JET)
         out = cv2.addWeighted(out, 0.5, heatmap, 0.5, 0)

--- a/tests/test_document_analyzer.py
+++ b/tests/test_document_analyzer.py
@@ -30,13 +30,13 @@ def test_initialize():
     analyzer = DocumentAnalyzer(configs=config, device=device, visualize=visualize)
 
     # サブモジュールのパラメータが更新されているか確認
-    assert analyzer.ocr.detector.device == torch.device(device)
-    assert analyzer.ocr.recognizer.device == torch.device(device)
+    assert analyzer.text_detector.device == torch.device(device)
+    assert analyzer.text_recognizer.device == torch.device(device)
     assert analyzer.layout.layout_parser.device == torch.device(device)
     assert analyzer.layout.table_structure_recognizer.device == torch.device(device)
 
-    assert analyzer.ocr.detector.visualize == visualize
-    assert analyzer.ocr.recognizer.visualize == visualize
+    assert analyzer.text_detector.visualize == visualize
+    assert analyzer.text_recognizer.visualize == visualize
     assert analyzer.layout.layout_parser.visualize == visualize
     assert analyzer.layout.table_structure_recognizer.visualize == visualize
 
@@ -50,12 +50,12 @@ def test_initialize():
     )
 
     assert (
-        analyzer.ocr.detector.post_processor.thresh
+        analyzer.text_detector.post_processor.thresh
         == text_detector_cfg.post_process.thresh
     )
 
     assert (
-        analyzer.ocr.recognizer.model.refine_iters == text_recognizer_cfg.refine_iters
+        analyzer.text_recognizer.model.refine_iters == text_recognizer_cfg.refine_iters
     )
 
     assert analyzer.layout.layout_parser.thresh_score == layout_parser_cfg.thresh_score

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -25,6 +25,7 @@ from yomitoku.layout_parser import Element, LayoutParserSchema
 from yomitoku.ocr import OCRSchema, WordPrediction
 from yomitoku.table_structure_recognizer import (
     TableCellSchema,
+    TableLineSchema,
     TableStructureRecognizerSchema,
 )
 from yomitoku.text_detector import TextDetectorSchema
@@ -78,14 +79,36 @@ def test_table_to_html():
             "contents": "",
         },
     ]
+
     cells = [TableCellSchema(**cell) for cell in cells]
+
+    rows = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    cols = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    rows = [TableLineSchema(**row) for row in rows]
+    cols = [TableLineSchema(**col) for col in cols]
+
     table = {
         "box": [0, 0, 100, 100],
         "n_row": 2,
         "n_col": 2,
         "cells": cells,
         "order": 0,
+        "rows": rows,
+        "cols": cols,
     }
+
     table = TableStructureRecognizerSchema(**table)
     expected = '<table border="1" style="border-collapse: collapse"><tr><td rowspan="2" colspan="1">dummy<br></td><td rowspan="1" colspan="1">dummy<br></td></tr><tr><td rowspan="1" colspan="1"></td></tr></table>'
     assert table_to_html(table, ignore_line_break=False)["html"] == expected
@@ -189,12 +212,32 @@ def test_table_to_md():
         },
     ]
     cells = [TableCellSchema(**cell) for cell in cells]
+
+    rows = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    cols = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    rows = [TableLineSchema(**row) for row in rows]
+    cols = [TableLineSchema(**col) for col in cols]
+
     table = {
         "box": [0, 0, 100, 100],
         "n_row": 2,
         "n_col": 2,
         "cells": cells,
         "order": 0,
+        "rows": rows,
+        "cols": cols,
     }
     table = TableStructureRecognizerSchema(**table)
 
@@ -234,12 +277,32 @@ def test_table_to_csv():
         },
     ]
     cells = [TableCellSchema(**cell) for cell in cells]
+
+    rows = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    cols = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    rows = [TableLineSchema(**row) for row in rows]
+    cols = [TableLineSchema(**col) for col in cols]
+
     table = {
         "box": [0, 0, 100, 100],
         "n_row": 2,
         "n_col": 2,
         "cells": cells,
         "order": 0,
+        "rows": rows,
+        "cols": cols,
     }
     table = TableStructureRecognizerSchema(**table)
 
@@ -314,12 +377,32 @@ def test_table_to_json():
         },
     ]
     cells = [TableCellSchema(**cell) for cell in cells]
+
+    rows = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    cols = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    rows = [TableLineSchema(**row) for row in rows]
+    cols = [TableLineSchema(**col) for col in cols]
+
     table = {
         "box": [0, 0, 100, 100],
         "n_row": 2,
         "n_col": 2,
         "cells": cells,
         "order": 0,
+        "rows": rows,
+        "cols": cols,
     }
     table = TableStructureRecognizerSchema(**table)
 
@@ -409,6 +492,23 @@ def test_export(tmp_path):
         "contents": "dummy\n",
     }
 
+    rows = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    cols = [
+        {
+            "box": [0, 0, 10, 10],
+            "score": 0.9,
+        }
+    ]
+
+    rows = [TableLineSchema(**row) for row in rows]
+    cols = [TableLineSchema(**col) for col in cols]
+
     table_cell = TableCellSchema(**table_cell)
     out_path = tmp_path / "table_cell.json"
     table_cell.to_json(out_path)
@@ -421,6 +521,8 @@ def test_export(tmp_path):
         "n_col": 2,
         "cells": [table_cell],
         "order": 0,
+        "rows": rows,
+        "cols": cols,
     }
 
     tsr = TableStructureRecognizerSchema(**tsr)


### PR DESCRIPTION
# WAHT
以下の課題の解決のためにテーブルに対するテキストを割り当てるためのアルゴリズムを改善
- 文字検出モデルのテキストボックスが複数セルに跨って検知された場合にうまく処理できない
- 文字検出モデルで検知したテキストボックスのセルに対する割当てがうまくいかず表の外に溢れることがある

# HOW
複数セルに跨って検知されるテキストボックスをセルの区切り位置で複数テキストに分割して処理を行う