### PR TITLE
文字が存在しない画像を処理時にHTMLのエクスポートに失敗するエラーの修正

### DIFF
--- a/src/yomitoku/export/export_html.py
+++ b/src/yomitoku/export/export_html.py
@@ -180,8 +180,13 @@ def convert_html(
     elements = sorted(elements, key=lambda x: x["order"])
 
     html_string = "".join([element["html"] for element in elements])
-    parsed_html = html.fromstring(html_string)
-    formatted_html = etree.tostring(parsed_html, pretty_print=True, encoding="unicode")
+    if not len(html_string) == 0:
+        parsed_html = html.fromstring(html_string)
+        formatted_html = etree.tostring(
+            parsed_html, pretty_print=True, encoding="unicode"
+        )
+    else:
+        formatted_html = ""
 
     return formatted_html, elements
 


### PR DESCRIPTION
# WHAT
文字が存在しないファイルに対して、HTMLでファイルエクスポートする際にエラーが発生する