### PR TITLE
PR経由でCHANGELOG.mdをpushすうるように変更

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -55,6 +55,9 @@
       labels:
         - "enhancement"
     default: patch
+  exclude-labels:
+    - "changelog"
+
   template: |
     ## 変更
   

--- a/.github/workflows/auto_changelog.yaml
+++ b/.github/workflows/auto_changelog.yaml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write     # PR を作成するため
+
 
 jobs:
   changelog:
@@ -30,14 +32,19 @@ jobs:
             --user ${{ github.repository_owner }} \
             --project ${{ github.event.repository.name }} \
             --no-issues
-      - name: Rebase (catch up)
-        run: |
-          git fetch origin main
-          git rebase origin/main
-      - name: Commit & push CHANGELOG
-        run: |
-          git config user.name  "github-actions"
-          git config user.email "actions@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "docs: update changelog"
-          git push origin HEAD:main
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/changelog-${{ github.run_id }}
+          title: "docs: Update CHANGELOG"
+          body: |
+            Automated CHANGELOG update triggered by Release Drafter.
+            - Workflow run: ${{ github.run_id }}
+          commit-message: "docs: update CHANGELOG"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: false 
+          delete-branch: true   
+          labels: |
+            changelog
+            automated

--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -7,9 +7,20 @@ permissions:
   contents: write
 jobs:
   deploy-docs:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.pull_requests | length) > 0 &&
+      startsWith(
+        github.event.workflow_run.pull_requests[0].head.ref,
+        'chore/changelog-'
+      )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          # pull_requests[0].head.sha = PR ブランチの最新コミット
+          ref: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,12 @@ permissions:
 
 jobs:
   update_release_draft:
+    if: |
+      github.event_name == 'push' ||
+      ! contains(
+        github.event.pull_request.labels.*.name,
+        'changelog'
+      )
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   lint-and-test:
+    if: "! startsWith(github.head_ref, 'chore/changelog-')"
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# WHAT
- PRを自動作成し、自動生成したCHANGELOG.mdをmainにpushする
- documentのビルドはこのとき行う
- unittestとlintは行わない
- 自動作成されるPRはリリースノートに含めない

# WHY
保護ブランチはgithub actionsからmainに直pushできないため、PRを経由する