### PR TITLE
相対パスを利用して対象画像ファイルを指定した際に、resultファイルが隠しファイルになってしまう問題を修正

### DIFF
--- a/src/yomitoku/cli/main.py
+++ b/src/yomitoku/cli/main.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import re
 import time
 from pathlib import Path
 
@@ -96,7 +97,7 @@ def process_single_file(args, analyzer, path, format):
     format_results = []
     for page, img in enumerate(imgs):
         result, ocr, layout = analyzer(img)
-        dirname = path.parent.name
+        dirname = _sanitize_path_component(path.parent.name)
         filename = path.stem
 
         # cv2.imwrite(
@@ -469,6 +470,13 @@ def main():
         process_single_file(args, analyzer, path, format)
         end = time.time()
         logger.info(f"Total Processing time: {end - start:.2f} sec")
+
+
+def _sanitize_path_component(component):
+    if not component:
+        return component
+
+    return re.sub(r'^\.+', lambda m: '_' * len(m.group(0)), component)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
例えば `../image.png` という相対パスを入力パラメータとして与えた際、既存実装ではresultファイルの名前が `.._image_p1.md` というふうになっていました。これは先頭のドットによって隠しファイルとして扱われてしまい、素朴な `ls` 等では表示がされなくなってしまうため、若干驚きがある挙動のように感じました。

このパッチではそういった「prependされているドット文字 (列)」をアンダースコアに置換するように変更しました。例えば上記の例では `___image_p1.md` というファイル名で結果が生成されるようになります。

FYI: In English, please refer to the commit message.