### PR TITLE
Explicitly set file encoding to UTF-8 to prevent UnicodeDecodeError.

### DIFF
--- a/scripts/generate_schmea_doc.py
+++ b/scripts/generate_schmea_doc.py
@@ -12,7 +12,7 @@ targets = [
 for target in targets:
     schema = target["schema"].model_json_schema()
     outpath = f"schemas/{target['name']}.json"
-    with open(outpath, "w") as f:
+    with open(outpath, "w", encoding="utf-8") as f:
         json.dump(schema, f, indent=2, ensure_ascii=False)
 
     # Generate HTML documentation for the schemas

--- a/src/yomitoku/base.py
+++ b/src/yomitoku/base.py
@@ -17,7 +17,7 @@ def load_yaml_config(path_config: str):
     if not path_config.exists():
         raise FileNotFoundError(f"Config file not found: {path_config}")
 
-    with open(path_config, "r") as file:
+    with open(path_config, "r", encoding="utf-8") as file:
         yaml_config = OmegaConf.load(file)
     return yaml_config
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -490,7 +490,7 @@ def test_export(tmp_path):
     out_path = tmp_path / "ocr.yaml"
     ocr.to_json(out_path)
 
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == ocr.model_dump()
 
     element = {"box": [0, 0, 10, 10], "score": 0.9, "role": None}
@@ -498,7 +498,7 @@ def test_export(tmp_path):
     out_path = tmp_path / "element.json"
     element.to_json(out_path)
 
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == element.model_dump()
 
     layout_parser = {
@@ -511,11 +511,11 @@ def test_export(tmp_path):
     out_path = tmp_path / "layout_parser.json"
     layout_parser.to_json(out_path)
 
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == layout_parser.model_dump()
 
     layout_parser.to_json(out_path, ignore_line_break=True)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == layout_parser.model_dump()
 
     table_cell = {
@@ -555,7 +555,7 @@ def test_export(tmp_path):
     table_cell = TableCellSchema(**table_cell)
     out_path = tmp_path / "table_cell.json"
     table_cell.to_json(out_path)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == table_cell.model_dump()
 
     tsr = {
@@ -572,7 +572,7 @@ def test_export(tmp_path):
     tsr = TableStructureRecognizerSchema(**tsr)
     out_path = tmp_path / "tsr.json"
     tsr.to_json(out_path)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == tsr.model_dump()
 
     layout_analyzer = {
@@ -584,7 +584,7 @@ def test_export(tmp_path):
     layout_analyzer = LayoutAnalyzerSchema(**layout_analyzer)
     out_path = tmp_path / "layout_analyzer.json"
     layout_analyzer.to_json(out_path)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == layout_analyzer.model_dump()
 
     paragraph = {
@@ -597,7 +597,7 @@ def test_export(tmp_path):
     paragraph = ParagraphSchema(**paragraph)
     out_path = tmp_path / "paragraph.json"
     paragraph.to_json(out_path)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == paragraph.model_dump()
 
     figure = {
@@ -609,7 +609,7 @@ def test_export(tmp_path):
     figure = FigureSchema(**figure)
     out_path = tmp_path / "figure.json"
     figure.to_json(out_path)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == figure.model_dump()
 
     document_analyzer = {
@@ -624,7 +624,7 @@ def test_export(tmp_path):
     document_analyzer = DocumentAnalyzerSchema(**document_analyzer)
     out_path = tmp_path / "document_analyzer.json"
     document_analyzer.to_json(out_path)
-    with open(out_path, "r") as f:
+    with open(out_path, "r", encoding="utf-8") as f:
         assert json.load(f) == document_analyzer.model_dump()
 
     document_analyzer.to_csv(tmp_path / "document_analyzer.csv", img=img)


### PR DESCRIPTION
On Windows systems, the default file encoding is often a legacy codepage like 'cp932'. When opening text-based files (like YAML configurations or JSON data) that are encoded in UTF-8, this can lead to a `UnicodeDecodeError` if the file contains characters not present in the default codepage.

This commit resolves the issue by explicitly specifying `encoding="utf-8"` in all relevant `open()` calls across the codebase, including in the core application logic, scripts, and tests. This ensures consistent behavior and prevents encoding-related errors across different operating systems.