### PR TITLE
feat: 検索可能PDFの読み取り順序を修正

### DIFF
--- a/src/yomitoku/cli/main.py
+++ b/src/yomitoku/cli/main.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import torch
+from PIL import Image
 
 from ..constants import SUPPORT_OUTPUT_FORMAT
 from ..data.functions import load_image, load_pdf
@@ -68,8 +69,9 @@ def save_merged_file(out_path, args, out, imgs):
     elif args.format == "md":
         save_markdown(out, out_path, args.encoding)
     elif args.format == "pdf":
+        pil_images = [Image.fromarray(img[:, :, ::-1]) for img in imgs]
         create_searchable_pdf(
-            imgs,
+            pil_images,
             out,
             output_path=out_path,
             font_path=args.font_path,
@@ -243,8 +245,9 @@ def process_single_file(args, analyzer, path, format):
             )
         elif format == "pdf":
             if not args.combine:
+                pil_image = Image.fromarray(img[:, :, ::-1])
                 create_searchable_pdf(
-                    [img],
+                    [pil_image],
                     [result],
                     output_path=out_path,
                     font_path=args.font_path,

--- a/src/yomitoku/utils/searchable_pdf.py
+++ b/src/yomitoku/utils/searchable_pdf.py
@@ -1,17 +1,18 @@
 import os
-
-from PIL import Image
 from io import BytesIO
 
-from reportlab.pdfgen import canvas
-from reportlab.pdfbase.ttfonts import TTFont
+import jaconv
+import numpy as np
+from PIL import Image
+from reportlab.lib.colors import Color
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.pdfmetrics import stringWidth
-
-import numpy as np
-import jaconv
+from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfgen import canvas
 
 from ..constants import ROOT_DIR
+from ..schemas import DocumentAnalyzerSchema
+from .misc import is_contained
 
 FONT_PATH = ROOT_DIR + "/resource/MPLUS1p-Medium.ttf"
 
@@ -61,7 +62,23 @@ def to_full_width(text):
     return jaconv_text
 
 
-def create_searchable_pdf(images, ocr_results, output_path, font_path=None):
+from typing import List
+
+def create_searchable_pdf(
+    images: List[Image.Image],
+    docs: List[DocumentAnalyzerSchema],
+    output_path: str,
+    font_path: str = None,
+):
+    """
+    Create a searchable PDF from an image and OCR results.
+
+    Args:
+        images (List[Image.Image]): A list of pillow images.
+        docs (List[DocumentAnalyzerSchema]): A list of OCR results.
+        output_path (str): Path to the output PDF file.
+        font_path (str, optional): Path to the font file. Defaults to None.
+    """
     if font_path is None:
         font_path = FONT_PATH
 
@@ -70,17 +87,85 @@ def create_searchable_pdf(images, ocr_results, output_path, font_path=None):
     packet = BytesIO()
     c = canvas.Canvas(packet)
 
-    for i, (image, ocr_result) in enumerate(zip(images, ocr_results)):
-        image = Image.fromarray(image[:, :, ::-1])  # Convert BGR to RGB
+    for i, (image, doc) in enumerate(zip(images, docs)):
         image_path = f"tmp_{i}.png"
         image.save(image_path)
         w, h = image.size
 
         c.setPageSize((w, h))
         c.drawImage(image_path, 0, 0, width=w, height=h)
-        os.remove(image_path)  # Clean up temporary image file
+        os.remove(image_path)
 
-        for word in ocr_result.words:
+        # Collect all text containers
+        containers = []
+        for p in doc.paragraphs:
+            containers.append(
+                {
+                    "box": p.box,
+                    "order": p.order,
+                    "sub_order": 0,
+                    "direction": p.direction,
+                    "type": "paragraph",
+                }
+            )
+        for t in doc.tables:
+            for cell in t.cells:
+                containers.append(
+                    {
+                        "box": cell.box,
+                        "order": t.order,
+                        "sub_order": (cell.row, cell.col),
+                        "direction": "horizontal",  # Assuming table text is horizontal
+                        "type": "table_cell",
+                    }
+                )
+        for f in doc.figures:
+            for para_idx, p in enumerate(f.paragraphs):
+                containers.append(
+                    {
+                        "box": p.box,
+                        "order": f.order,
+                        "sub_order": para_idx,
+                        "direction": p.direction,
+                        "type": "figure_paragraph",
+                    }
+                )
+
+        # Sort containers by reading order
+        containers = sorted(containers, key=lambda c: (c["order"], c["sub_order"]))
+
+        all_words = []
+        for container in containers:
+            container_words = []
+            for word in doc.words:
+                word_box = _poly2rect(word.points)
+                if is_contained(container["box"], word_box, 0.7):
+                    container_words.append(word)
+
+            # Sort words within the container
+            if container["direction"] == "vertical":
+                # Right-to-left column, then top-to-bottom
+                container_words.sort(
+                    key=lambda w: (
+                        -_poly2rect(w.points)[0],
+                        _poly2rect(w.points)[1],
+                    )
+                )
+            else:
+                # Top-to-bottom, then left-to-right
+                container_words.sort(
+                    key=lambda w: (
+                        _poly2rect(w.points)[1],
+                        _poly2rect(w.points)[0],
+                    )
+                )
+            all_words.extend(container_words)
+
+        # Set transparent color for text
+        text_color = Color(1, 1, 1, alpha=0)
+        c.setFillColor(text_color)
+
+        for word in all_words:
             text = word.content
             bbox = _poly2rect(word.points)
             direction = word.direction
@@ -91,26 +176,35 @@ def create_searchable_pdf(images, ocr_results, output_path, font_path=None):
 
             if direction == "vertical":
                 text = to_full_width(text)
-
-            if direction == "horizontal":
-                font_size = _calc_font_size(text, bbox_height, bbox_width)
-            else:
                 font_size = _calc_font_size(text, bbox_width, bbox_height)
+            else:
+                font_size = _calc_font_size(text, bbox_height, bbox_width)
+
+            if not font_size:
+                continue
 
             c.setFont("MPLUS1p-Medium", font_size)
-            c.setFillColorRGB(1, 1, 1, alpha=0)  # 透明
+
             if direction == "vertical":
-                base_y = h - y2 + (bbox_height - font_size)
+                # Adjust for vertical text rendering
+                base_y = h - y1
+                char_height = bbox_height / len(text) if text else 0
+
                 for j, ch in enumerate(text):
+                    char_x = x1 + (bbox_width - font_size) / 2
+                    char_y = base_y - (j * char_height) - char_height / 2
+
                     c.saveState()
-                    c.translate(x1 + font_size * 0.5, base_y - (j - 1) * font_size)
+                    c.translate(char_x + font_size / 2, char_y - font_size / 2)
                     c.rotate(-90)
                     c.drawString(0, 0, ch)
                     c.restoreState()
             else:
                 base_y = h - y2 + (bbox_height - font_size) * 0.5
                 c.drawString(x1, base_y, text)
+
         c.showPage()
+
     c.save()
 
     with open(output_path, "wb") as f:


### PR DESCRIPTION
この修正は、検索可能PDF生成機能における読み取り順序の問題を解決します。

主な変更点:
- `create_searchable_pdf`関数をリファクタリングし、生のOCR結果の代わりに、読み取り順序情報を含む`DocumentAnalyzerSchema`を受け取るように変更しました。
- テキストコンテナ（段落、表のセル、図の段落）を`order`および`sub_order`属性に基づいてソートするロジックを実装しました。
- 各コンテナ内の単語を、テキストの向き（縦書き・横書き）を考慮してソートするようにしました。
- CLIの呼び出し部分を更新し、リファクタリングされた関数に正しいデータを渡すように修正しました。

これにより、生成されるPDFのテキストレイヤーが、YomiTokuによって計算された論理的な読み取り順序に正確に従うようになり、スクリーンリーダーなどでのアクセシビリティが大幅に向上します。

Closes #147