### PR TITLE
モデルのダウンロードコマンドの実装

### DIFF
--- a/docs/module.en.md
+++ b/docs/module.en.md
@@ -121,35 +121,15 @@ Storing the Path to a YAML File in the Config
 
 <!--/codeinclude-->
 
-## Using in an Offline Environment
 
-Yomitoku automatically downloads models from Hugging Face Hub during the first execution, requiring an internet connection at that time. However, by manually downloading the models in advance, it can be executed in an offline environment.
+## Using Yomitoku in Offline Environments
 
-1. Install [Git Large File Storage](https://docs.github.com/ja/repositories/working-with-files/managing-large-files/installing-git-large-file-storage)
-2. In an environment with internet access, download the model repository. Copy the cloned repository to your target environment using your preferred tools.
+Yomitoku automatically downloads the model from Hugging Face Hub on its first run.
+An internet connection is required at that time, but by manually downloading the model beforehand, you can also run Yomitoku in environments without internet access.
 
-The following is the command to download the model repository from Hugging Face Hub.
-
-```sh
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-table-structure-recognizer-rtdtrv2-open-beta
-
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-layout-parser-rtdtrv2-open-beta
-
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-text-detector-dbnet-open-beta
-
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-text-recognizer-parseq-open-beta
+```
+download_model
 ```
 
-3. Place the model repository directly under the root directory of the Yomitoku repository and reference the local model repository in the `hf_hub_repo` field of the YAML file. Below is an example of `text_detector.yaml`. Similarly, define YAML files for other modules as well.
+By placing the downloaded repository folder `KotaroKinoshita` in the current directory at runtime, the local repository model will be loaded and executed without any internet connection.
 
-```yaml
-hf_hub_repo: yomitoku-text-detector-dbnet-open-beta
-```
-
-4. Storing the Path to a YAML File in the Config
-
-<!--codeinclude-->
-
-[demo/setting_document_anaysis.py](../demo/setting_document_anaysis.py)
-
-<!--/codeinclude-->

--- a/docs/module.ja.md
+++ b/docs/module.ja.md
@@ -127,32 +127,8 @@ yaml ファイルのパスを config に格納する
 
 Yomitoku は初回の実行時に HuggingFaceHub からモデルを自動でダウンロードします。その際にインターネット環境が必要ですが、事前に手動でダウンロードすることでインターネットに接続できない環境でも実行することが可能です。
 
-1. [Git Large File Storage](https://docs.github.com/ja/repositories/working-with-files/managing-large-files/installing-git-large-file-storage)をインストール
-
-2. 事前にインターネットに接続できる環境でモデルリポジトリをダウンロードします。クローンしたリポジトリはご自身のツールで動作環境にコピーしてください。
-
-以下は huggingfacehub からモデルリポジトリをダウンロードするコマンド
-
-```sh
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-table-structure-recognizer-rtdtrv2-open-beta
-
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-layout-parser-rtdtrv2-open-beta
-
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-text-detector-dbnet-open-beta
-
-git clone https://huggingface.co/KotaroKinoshita/yomitoku-text-recognizer-parseq-open-beta
+```
+download_model
 ```
 
-3. yomitoku のリポジトリの直下にモデルリポジトリを配置し、yaml ファイルの`hf_hub_repo`でローカルのモデルレポジトリを参照します。以下は `text_detector.yaml` の例です。同様に他のモジュールに対しても yaml ファイルを定義します。
-
-```yaml
-hf_hub_repo: yomitoku-text-detector-dbnet-open-beta
-```
-
-4. yaml ファイルのパスを config に格納する
-
-<!--codeinclude-->
-
-[demo/setting_document_anaysis.py](../demo/setting_document_anaysis.py)
-
-<!--/codeinclude-->
+実行時にダウンロードされたリポジトリのフォルダ`KotaroKinoshita`をカレントディレクトリに配置することで、インターネットへの接続なしに、ローカルリポジトリのモデルが呼び出され実行されます。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ explicit = true
 [project.scripts]
 yomitoku = "yomitoku.cli.main:main"
 yomitoku_mcp = "yomitoku.cli.mcp_server:main"
+download_model = "yomitoku.cli.download_model:main"
 
 [project.optional-dependencies]
 mcp = [

--- a/src/yomitoku/cli/download_model.py
+++ b/src/yomitoku/cli/download_model.py
@@ -1,0 +1,35 @@
+import argparse
+import os
+
+from huggingface_hub import snapshot_download
+from yomitoku.configs import DEFAULT_CONFIGS
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hf_hub_repo", type=str, default=None)
+    parser.add_argument("--local", type=str, default="KotaroKinoshita")
+    args = parser.parse_args()
+
+    if args.hf_hub_repo is None:
+        for config in DEFAULT_CONFIGS:
+            model_name = config.hf_hub_repo.split("/")[-1]
+            local_repo = os.path.join(args.local, model_name)
+            snapshot_download(
+                repo_id=config.hf_hub_repo,
+                revision="main",
+                local_dir=local_repo,
+            )
+    else:
+        model_name = args.hf_hub_repo.split("/")[-1]
+        local_repo = os.path.join(args.local, model_name)
+
+        snapshot_download(
+            repo_id=args.hf_hub_repo,
+            revision="main",
+            local_dir=local_repo,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/yomitoku/configs/__init__.py
+++ b/src/yomitoku/configs/__init__.py
@@ -9,6 +9,12 @@ from .cfg_text_recognizer_parseq import TextRecognizerPARSeqConfig
 from .cfg_text_recognizer_parseq_small import TextRecognizerPARSeqSmallConfig
 from .cfg_text_recognizer_parseq_v2 import TextRecognizerPARSeqV2Config
 
+DEFAULT_CONFIGS = [
+    TextRecognizerPARSeqV2Config,
+    TextDetectorDBNetV2Config,
+    LayoutParserRTDETRv2V2Config,
+    TableStructureRecognizerRTDETRv2Config,
+]
 
 __all__ = [
     "TextDetectorDBNetConfig",

--- a/src/yomitoku/configs/cfg_text_recognizer_parseq_v2.py
+++ b/src/yomitoku/configs/cfg_text_recognizer_parseq_v2.py
@@ -8,7 +8,7 @@ from ..constants import ROOT_DIR
 class Data:
     num_workers: int = 4
     batch_size: int = 128
-    img_size: List[int] = field(default_factory=lambda: [32, 400])
+    img_size: List[int] = field(default_factory=lambda: [32, 800])
 
 
 @dataclass
@@ -40,7 +40,7 @@ class TextRecognizerPARSeqV2Config:
     hf_hub_repo: str = "KotaroKinoshita/yomitoku-text-recognizer-parseq-middle-v2"
     charset: str = str(ROOT_DIR + "/resource/charset.txt")
     num_tokens: int = 7312
-    max_label_length: int = 50
+    max_label_length: int = 100
     decode_ar: int = 1
     refine_iters: int = 1
 

--- a/src/yomitoku/configs/cfg_text_recognizer_parseq_v2.py
+++ b/src/yomitoku/configs/cfg_text_recognizer_parseq_v2.py
@@ -8,7 +8,7 @@ from ..constants import ROOT_DIR
 class Data:
     num_workers: int = 4
     batch_size: int = 128
-    img_size: List[int] = field(default_factory=lambda: [32, 800])
+    img_size: List[int] = field(default_factory=lambda: [32, 400])
 
 
 @dataclass
@@ -40,7 +40,7 @@ class TextRecognizerPARSeqV2Config:
     hf_hub_repo: str = "KotaroKinoshita/yomitoku-text-recognizer-parseq-middle-v2"
     charset: str = str(ROOT_DIR + "/resource/charset.txt")
     num_tokens: int = 7312
-    max_label_length: int = 100
+    max_label_length: int = 50
     decode_ar: int = 1
     refine_iters: int = 1
 


### PR DESCRIPTION
# WHAT
ローカルへモデルを一括もしくは、選択したモデルをダウンロードするためのCLIコマンドを実装
ワンコマンドでモデルをダウンロード実現を可能にし、オフライン環境時のモデルのダウンロードの手間を削減する