### PR TITLE
Changelog CIで"skip changelog"ラベルが割り振られているプルリクエストはスキップするように設定

### DIFF
--- a/.github/workflows/auto_changelog.yaml
+++ b/.github/workflows/auto_changelog.yaml
@@ -33,7 +33,8 @@ jobs:
           github_changelog_generator \
             --user ${{ github.repository_owner }} \
             --project ${{ github.event.repository.name }} \
-            --no-issues
+            --no-issues \
+            --exclude-labels "duplicate,question,invalid,wontfix,skip changelog"
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
PR149で問題が発生してChangelog CIがうまく動作していませんでした。

PR149に"skip changelog"ラベルを追加し、Changelog CIで"skip changelog"ラベルが割り振られているプルリクエストはスキップするように設定しました。