### PR TITLE
fix: add MPS device support for Apple Silicon

### DIFF
--- a/src/yomitoku/base.py
+++ b/src/yomitoku/base.py
@@ -111,6 +111,12 @@ class BaseModule:
             else:
                 self._device = torch.device("cpu")
                 logger.warning("CUDA is not available. Use CPU instead.")
+        elif "mps" in device:
+            if torch.backends.mps.is_available():
+                self._device = torch.device("mps")
+            else:
+                self._device = torch.device("cpu")
+                logger.warning("MPS is not available. Use CPU instead.")
         else:
             self._device = torch.device("cpu")
 


### PR DESCRIPTION
## Summary

First of all, thank you for creating such an amazing OCR library for Japanese documents! YomiToku has been incredibly helpful for my projects. 🙏

This PR fixes the MPS device support that was documented but not actually implemented.

## Problem

The documentation states that `device="mps"` is a supported option:

> device: 処理に用いるデバイスを指定します。（指定値: cuda | cpu | mps）
>https://kotaro-kinoshita.github.io/yomitoku/module/

However, the current implementation in `base.py` only checks for CUDA and falls back to CPU for all other devices, including MPS:

```python
# Before
if "cuda" in device:
    # CUDA handling
else:
    self._device = torch.device("cpu")  # MPS also falls here
```

## Solution

Added proper MPS device detection using `torch.backends.mps.is_available()`:

```python
# After
if "cuda" in device:
    # CUDA handling
elif "mps" in device:
    if torch.backends.mps.is_available():
        self._device = torch.device("mps")
    else:
        self._device = torch.device("cpu")
        logger.warning("MPS is not available. Use CPU instead.")
else:
    self._device = torch.device("cpu")
```

## Benchmark Results

Tested on Apple Silicon Mac (M-series) with `tests/data/test.jpg` (842x596):

| Device | OCR Time | Speedup |
|--------|----------|---------|
| CPU | 1.188s | - |
| MPS | 0.323s | **3.7x faster** |

### Accuracy Verification

OCR results are **identical** between CPU and MPS:

| Word | CPU det | CPU rec | MPS det | MPS rec |
|------|---------|---------|---------|---------|
| `(2)` | 0.579 | 0.053 | 0.579 | 0.053 |
| `Dummy` | 0.889 | 0.998 | 0.889 | 0.998 |
| `Test` | 0.878 | 0.996 | 0.878 | 0.996 |
| `これはテスト用のPDFデータです` | 0.862 | 0.877 | 0.862 | 0.877 |
| `Test用` | 0.897 | 0.938 | 0.897 | 0.938 |

## Test Plan

- [x] All existing tests pass (`pytest`: 55 passed)
- [x] Verified MPS acceleration works on Apple Silicon
- [x] Verified OCR accuracy is identical between CPU and MPS
- [x] Backward compatible - no changes to existing API