### PR TITLE
ExtractorにおいてKeyに対して複数値が存在する場合のマージオプションの追加

### DIFF
--- a/docs/extractor.en.md
+++ b/docs/extractor.en.md
@@ -181,6 +181,8 @@ fields:
 | `type` | string | - | `"string"` | Value type: `string`, `number`, `date` |
 | `structure` | string | - | `"scalar"` | Data structure: `scalar`, `kv` (both KV format), or `table` |
 | `normalize` | string | - | `null` | Normalization rule name |
+| `merge_values` | bool | - | `false` | Merge multiple values for the same key into one string (KV fields only) |
+| `separator` | string | - | `"\n"` | Separator used when `merge_values: true` |
 | `columns` | list | - | `null` | Column definitions (for table-structure fields) |
 
 ---
@@ -276,6 +278,29 @@ fields:
     type: number
     normalize: numeric
 ```
+
+#### merge_values (Merging Multiple Values)
+
+In KV fields, a single key may be associated with multiple value cells (e.g., when an address spans multiple rows). By default, only the first value is extracted. Setting `merge_values: true` collects all values, sorts them by position, and joins them with the specified `separator`.
+
+```yaml
+fields:
+  # Address split across multiple cells — merge into one string
+  - name: address
+    structure: kv
+    description: Address
+    type: string
+    merge_values: true
+    separator: ""          # No separator (default is newline)
+
+  # Name is a single cell — no merging needed (default behavior)
+  - name: full_name
+    structure: kv
+    description: Full Name
+    type: string
+```
+
+Sort order is automatically determined by the positions of the value cells. If the vertical spread (Y) is greater than or equal to the horizontal spread (X), values are sorted top-to-bottom; otherwise, left-to-right.
 
 **Search order in rule-based extraction:**
 

--- a/docs/extractor.ja.md
+++ b/docs/extractor.ja.md
@@ -181,6 +181,8 @@ fields:
 | `type` | string | - | `"string"` | 値の型。`string`, `number`, `date` |
 | `structure` | string | - | `"scalar"` | データ構造。`scalar`、`kv`（いずれもKV形式）、または `table` |
 | `normalize` | string | - | `null` | 正規化ルール名 |
+| `merge_values` | bool | - | `false` | 同一キーに複数のvalueがある場合に結合する（KVフィールドのみ） |
+| `separator` | string | - | `"\n"` | `merge_values: true` 時のvalue結合セパレータ |
 | `columns` | list | - | `null` | テーブル構造の場合の列定義 |
 
 ---
@@ -276,6 +278,29 @@ fields:
     type: number
     normalize: numeric
 ```
+
+#### merge_values（複数値の結合）
+
+KVフィールドにおいて、同一のキーに複数のvalue（値セル）が紐づく場合があります（例: 住所が複数行に分かれている場合）。デフォルトでは最初の1件のみが抽出されますが、`merge_values: true` を指定することで、すべてのvalueを位置順にソートして `separator` で結合した結果を取得できます。
+
+```yaml
+fields:
+  # 住所が複数セルに分かれている場合、結合して取得
+  - name: address
+    structure: kv
+    description: 住所
+    type: string
+    merge_values: true
+    separator: ""          # セパレータなしで結合（デフォルトは改行）
+
+  # 氏名は1セルなので結合不要（デフォルト動作）
+  - name: full_name
+    structure: kv
+    description: 氏名
+    type: string
+```
+
+ソート順は値セルの位置に基づいて自動判定されます。Y方向の広がりがX方向以上の場合は上から下へ、それ以外は左から右へソートされます。
 
 **ルールベース抽出での検索順序:**
 

--- a/src/yomitoku/extractor/rule_pipeline.py
+++ b/src/yomitoku/extractor/rule_pipeline.py
@@ -152,24 +152,58 @@ def _extract_scalar_field(semantic_info, field_schema):
     if field_schema.description:
         kv_results = semantic_info.search_kv_items_by_key(field_schema.description)
         if kv_results:
-            kv = kv_results[0]
-            value_cell = kv["value"]
-            if value_cell is not None:
-                contents = value_cell.contents or ""
-                return ResolvedField(
-                    name=field_schema.name,
-                    value=contents,
-                    raw_text=contents,
-                    elements=[
-                        ResolvedElement(
-                            id=value_cell.id,
-                            box=list(value_cell.box),
-                            contents=contents,
-                        )
-                    ],
-                    confidence="high",
-                    source="kv",
-                )
+            if getattr(field_schema, "merge_values", False) and len(kv_results) > 1:
+                # 複数valueを結合
+                value_cells = [
+                    kv["value"] for kv in kv_results if kv["value"] is not None
+                ]
+                if value_cells:
+                    # 位置でソート（Y方向の広がり >= X方向ならY順、そうでなければX順）
+                    boxes = [cell.box for cell in value_cells]
+                    x_spread = max(b[0] for b in boxes) - min(b[0] for b in boxes)
+                    y_spread = max(b[1] for b in boxes) - min(b[1] for b in boxes)
+                    if y_spread >= x_spread:
+                        value_cells.sort(key=lambda c: c.box[1])
+                    else:
+                        value_cells.sort(key=lambda c: c.box[0])
+
+                    sep = field_schema.separator
+                    contents = sep.join(c.contents or "" for c in value_cells)
+                    raw_text = sep.join(c.contents or "" for c in value_cells)
+                    return ResolvedField(
+                        name=field_schema.name,
+                        value=contents,
+                        raw_text=raw_text,
+                        elements=[
+                            ResolvedElement(
+                                id=c.id,
+                                box=list(c.box),
+                                contents=c.contents or "",
+                            )
+                            for c in value_cells
+                        ],
+                        confidence="high",
+                        source="kv",
+                    )
+            else:
+                kv = kv_results[0]
+                value_cell = kv["value"]
+                if value_cell is not None:
+                    contents = value_cell.contents or ""
+                    return ResolvedField(
+                        name=field_schema.name,
+                        value=contents,
+                        raw_text=contents,
+                        elements=[
+                            ResolvedElement(
+                                id=value_cell.id,
+                                box=list(value_cell.box),
+                                contents=contents,
+                            )
+                        ],
+                        confidence="high",
+                        source="kv",
+                    )
 
     if field_schema.description:
         for table in semantic_info.tables:

--- a/src/yomitoku/extractor/schema.py
+++ b/src/yomitoku/extractor/schema.py
@@ -38,6 +38,11 @@ class FieldSchema(BaseModel):
     normalize: Optional[str] = Field(
         None, description="Normalization rule name (for scalar fields)"
     )
+    merge_values: bool = Field(
+        False,
+        description="If True, merge multiple values for the same key into one string",
+    )
+    separator: str = Field("\n", description="Separator used when merge_values is True")
     columns: Optional[List[ColumnSchema]] = Field(
         None, description="Column definitions (for table fields)"
     )


### PR DESCRIPTION
## Summary

- KVフィールドで同一キーに複数のvalueが紐づく場合（住所が複数行に分かれているケース等）に、値が取得できない問題を修正
- YAMLスキーマに `merge_values` / `separator` オプションを追加し、項目ごとに複数値の結合有無と結合文字を制御可能に
- ルールベース抽出（`yomitoku_extract`）の `_extract_scalar_field` で複数KV結果を位置順にソート・結合して返却するロジックを実装

## Changes

### `src/yomitoku/extractor/schema.py`
- `FieldSchema` に `merge_values: bool`（デフォルト `false`）と `separator: str`（デフォルト `"\n"`）を追加

### `src/yomitoku/extractor/rule_pipeline.py`
- `_extract_scalar_field` のKV検索部分を拡張
  - `merge_values=true` かつ複数結果がある場合: 全valueセルを位置ソート（Y/X広がりで自動判定）して `separator` で結合
  - `merge_values=false`（デフォルト）: 従来通り最初の1件を返却

### `docs/extractor.ja.md` / `docs/extractor.en.md`
- フィールド共通パラメータ表に `merge_values` / `separator` を追記
- KVフィールドセクションに使用例とソート動作の説明を追加

## Usage

```yaml
fields:
  # 複数セルに分かれた住所を結合して取得
  - name: address
    structure: kv
    description: 住所
    merge_values: true
    separator: ""

  # 単一セルの項目は従来通り（デフォルト動作）
  - name: full_name
    structure: kv
    description: 氏名
```

## Test plan

- [x] 既存テスト113件が全て合格
- [x] `merge_values: true` を設定した帳票で複数値が正しく結合されることを確認
- [x] `merge_values: false`（デフォルト）で従来通りの動作を確認
- [x] 縦方向・横方向それぞれの結合ソート順が正しいことを確認
