### PR TITLE
load_pdfを遅延レンダリング方式に変更しOOMを防止

### DIFF
--- a/src/yomitoku/data/__init__.py
+++ b/src/yomitoku/data/__init__.py
@@ -1,3 +1,3 @@
-from .functions import load_image, load_pdf
+from .functions import load_image, load_pdf, PdfPageIterator
 
-__all__ = ["load_image", "load_pdf"]
+__all__ = ["load_image", "load_pdf", "PdfPageIterator"]

--- a/src/yomitoku/data/functions.py
+++ b/src/yomitoku/data/functions.py
@@ -78,15 +78,65 @@ def load_image(image_path: str) -> np.ndarray:
     return pages
 
 
-def load_pdf(pdf_path: str, dpi=200) -> list[np.ndarray]:
+class PdfPageIterator:
+    """PDF ページを1ページずつ遅延レンダリングするイテレータ。
+
+    全ページを一括でメモリに展開せず、1 ページずつレンダリングして yield
+    することで、数百ページ超の PDF でも OOM を回避する。
+
+    Attributes:
+        total_pages (int): PDF の総ページ数。
     """
-    Open a PDF file.
+
+    def __init__(self, pdf_path: Path, dpi: int = 200):
+        self._pdf_path = pdf_path
+        self._dpi = dpi
+
+        try:
+            doc = pypdfium2.PdfDocument(pdf_path)
+            self.total_pages = len(doc)
+            doc.close()
+        except Exception as e:
+            raise ValueError(f"Failed to open the PDF file: {pdf_path}") from e
+
+    def __len__(self):
+        return self.total_pages
+
+    def __iter__(self):
+        try:
+            doc = pypdfium2.PdfDocument(self._pdf_path)
+        except Exception as e:
+            raise ValueError(f"Failed to open the PDF file: {self._pdf_path}") from e
+
+        try:
+            for i in range(self.total_pages):
+                page = doc[i]
+                bitmap = page.render(scale=self._dpi / 72)
+                pil_image = bitmap.to_pil()
+                img = np.array(pil_image.convert("RGB"))[:, :, ::-1]
+                yield img
+        finally:
+            doc.close()
+
+
+def load_pdf(pdf_path: str, dpi=200) -> PdfPageIterator:
+    """
+    Load a PDF file and return an iterator that yields page images in BGR format.
+
+    Pages are rendered lazily one at a time to avoid loading all pages into
+    memory at once, preventing OOM errors for large PDFs with hundreds of pages.
 
     Args:
-        pdf_path (str): path to the PDF file
+        pdf_path (str): The path to the PDF file to be loaded.
+        dpi (int, optional): The resolution for rendering. Defaults to 200.
 
     Returns:
-        list[np.ndarray]: list of image data(BGR)
+        PdfPageIterator: An iterator yielding NumPy arrays (BGR format) for each page.
+            Has a `total_pages` attribute and supports `len()`.
+
+    Raises:
+        FileNotFoundError: If the specified PDF file does not exist.
+        ValueError: If the file format is not supported or not a valid PDF.
     """
 
     pdf_path = Path(pdf_path)
@@ -104,20 +154,7 @@ def load_pdf(pdf_path: str, dpi=200) -> list[np.ndarray]:
             "image file is not supported by load_pdf(). Use load_image() instead."
         )
 
-    try:
-        doc = pypdfium2.PdfDocument(pdf_path)
-        renderer = doc.render(
-            pypdfium2.PdfBitmap.to_pil,
-            scale=dpi / 72,
-        )
-        images = list(renderer)
-        images = [np.array(image.convert("RGB"))[:, :, ::-1] for image in images]
-
-        doc.close()
-    except Exception as e:
-        raise ValueError(f"Failed to open the PDF file: {pdf_path}") from e
-
-    return images
+    return PdfPageIterator(pdf_path, dpi=dpi)
 
 
 def resize_shortest_edge(

--- a/src/yomitoku/models/layers/rtdetr_hybrid_encoder.py
+++ b/src/yomitoku/models/layers/rtdetr_hybrid_encoder.py
@@ -348,9 +348,9 @@ class HybridEncoder(nn.Module):
         grid_w = torch.arange(int(w), dtype=torch.float32)
         grid_h = torch.arange(int(h), dtype=torch.float32)
         grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
-        assert (
-            embed_dim % 4 == 0
-        ), "Embed dimension must be divisible by 4 for 2D sin-cos position embedding"
+        assert embed_dim % 4 == 0, (
+            "Embed dimension must be divisible by 4 for 2D sin-cos position embedding"
+        )
         pos_dim = embed_dim // 4
         omega = torch.arange(pos_dim, dtype=torch.float32) / pos_dim
         omega = 1.0 / (temperature**omega)

--- a/src/yomitoku/models/layers/rtdetrv2_decoder.py
+++ b/src/yomitoku/models/layers/rtdetrv2_decoder.py
@@ -92,9 +92,9 @@ class MSDeformableAttention(nn.Module):
         self.method = method
 
         self.head_dim = embed_dim // num_heads
-        assert (
-            self.head_dim * num_heads == self.embed_dim
-        ), "embed_dim must be divisible by num_heads"
+        assert self.head_dim * num_heads == self.embed_dim, (
+            "embed_dim must be divisible by num_heads"
+        )
 
         self.sampling_offsets = nn.Linear(embed_dim, self.total_points * 2)
         self.attention_weights = nn.Linear(embed_dim, self.total_points)


### PR DESCRIPTION
# WHAT
数百ページ超のPDFで全ページを一括メモリ展開していた load_pdf をPdfPageIterator による1ページずつの遅延レンダリングに変更。既存の呼び出し箇所は len() / for...in パターンのため変更不要。