### PR TITLE
fix: BGR画像でテキスト認識処理を実施するバグを修正

### DIFF
--- a/src/yomitoku/data/dataset.py
+++ b/src/yomitoku/data/dataset.py
@@ -16,7 +16,6 @@ class ParseqDataset(Dataset):
         self.img = img[:, :, ::-1]
         self.quads = quads
         self.cfg = cfg
-        self.img = img
         self.transform = T.Compose(
             [
                 T.ToTensor(),


### PR DESCRIPTION
# WHAT
不要な self.img = img の行が、直前の BGR→RGB 変換（self.img = img[:, :, ::-1]）を即座に上書きしていたため、PARSeq モデルに期待される RGB 入力ではなく BGR 入力が渡されていました。

このプルリクエストでは、dataset クラスの初期化処理に小さな修正を加えています。冗長な self.img への代入を削除し、画像が意図した形式でのみ保持されるようにしました。

src/yomitoku/data/dataset.py の __init__ メソッド内にある self.img への重複代入を削除し、画像のチャンネル順が意図どおり維持されるようにしました。

#201 