### PR TITLE
fix: バッチサイズの動的化のため PARSeq ONNX エクスポートの定数畳み込みを無効化

### DIFF
--- a/src/yomitoku/text_recognizer.py
+++ b/src/yomitoku/text_recognizer.py
@@ -146,7 +146,7 @@ class TextRecognizer(BaseModule):
             opset_version=16,
             input_names=["input"],
             output_names=["output"],
-            do_constant_folding=True,
+            do_constant_folding=False,
             dynamic_axes=dynamic_axes,
         )
 


### PR DESCRIPTION
## Summary

`infer_onnx=True` 設定時、TextRecognizer の ONNX 推論が `Reshape` エラーで
クラッシュする問題を修正します。

## Problem

`convert_onnx()` で `do_constant_folding=True` を指定していたため、
ONNX エクスポート時（batch_size=1）に MHA 内部の Reshape ターゲット
`seq_len * batch_size = 101 * 1 = 101` が定数に畳み込まれていました。

推論時に batch_size > 1（テキスト領域数が複数）になると、
`(101, N, 512)` のテンソルを `(101, 512)` に Reshape しようとして失敗します。

```
[ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION :
Non-zero status code returned while running Reshape node.
Name:'gemm_input_reshape_token_1892'
input_shape_size == size was false.
Input shape:{101,45,512}, requested shape:{101,512}
```

## Fix

`do_constant_folding=False` に変更し、`seq_len * batch_size` の乗算を
動的計算として残すことで、実行時の実際の batch_size で正しく計算されるようにします。

`dynamic_axes` はモデルの入出力テンソルにしか適用されないため、
MHA 内部の Reshape ノードには伝播しません。
`do_constant_folding=False` がこの問題に対する最小かつ安全な修正です。

## Impact

定数畳み込みを無効にすることで ONNX グラフの Shape 系計算がランタイムに
実行されますが、推論コストの大半は行列積（Linear/Attention）であるため、
実測の速度差は無視できる水準です。

## Note

既存のキャッシュ済み ONNX ファイルは古い形式のため削除が必要です。

```bash
rm src/yomitoku/onnx/yomitoku-text-recognizer-*.onnx
```

次回 `infer_onnx=True` で実行すると自動的に再生成されます。

## Issue
#211 
