### PR TITLE
feat: 図表エクスポート時にJSONへ画像の相対パスを格納

### DIFF
--- a/src/yomitoku/export/export_json.py
+++ b/src/yomitoku/export/export_json.py
@@ -34,6 +34,7 @@ def save_figure(
         figure_name = f"{filename}_figure_{i}.png"
         figure_path = os.path.join(save_dir, figure_name)
         save_image(figure_img, figure_path)
+        figure.figure_path = os.path.join(figure_dir, figure_name)
 
 
 def convert_json(inputs, out_path, ignore_line_break, img, export_figure, figure_dir):

--- a/src/yomitoku/schemas/document_analyzer.py
+++ b/src/yomitoku/schemas/document_analyzer.py
@@ -202,6 +202,10 @@ class FigureSchema(BaseSchema):
     direction: Union[str, None] = Field(
         ..., description="Text direction, e.g., ['horizontal' or 'vertical']"
     )
+    figure_path: Union[str, None] = Field(
+        None,
+        description="Relative path to the exported figure image from the output file",
+    )
 
 
 class DocumentAnalyzerSchema(BaseSchema):


### PR DESCRIPTION
## 概要

`DocumentAnalyzer` の JSON 出力で図画像をエクスポートした際 (`export_figure=True` / CLI `--figure`)、エクスポートした図画像の相対パスを JSON 内に格納するようにしました。

## 変更内容

- `FigureSchema` にオプショナルフィールド `figure_path` を追加(デフォルト `None`)
- `export_json.py` の `save_figure()` で図画像を保存した直後に、JSONファイルからの相対パス(例: `figures/<name>_figure_0.png`)を `figure_path` にセット

## 出力例

```json
"figures": [
    {
        "box": [10, 10, 60, 60],
        "figure_path": "figures/result_figure_0.png",
        ...
    }
]
```

## 互換性

- `figure_path` はデフォルト `None` のオプショナルフィールドのため、既存の生成コード・既存JSONの読み込みに影響なし
- `export_figure=False` 時や HTML/Markdown 等の他形式では従来どおり `null`

## テスト

- `tests/test_export.py` 全件パス
- CLI (`yomitoku demo/sample_text.jpg -f json --figure`) で相対パス格納と画像ファイルの実在を確認
- `--combine` 分岐も同じ `save_figure` 経路のため同様に格納されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)