### PR TITLE
ci: changelog自動更新の無限ループを修正

### DIFF
--- a/.github/workflows/auto_changelog.yaml
+++ b/.github/workflows/auto_changelog.yaml
@@ -15,7 +15,10 @@ permissions:
 
 jobs:
   changelog:
-    if: ${{ github.event.pull_request.merged == true }}
+    # changelog 更新PR自身のマージで再発火すると無限ループになるため除外する
+    if: >-
+      ${{ github.event.pull_request.merged == true &&
+          !startsWith(github.event.pull_request.head.ref, 'chore/changelog-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +37,7 @@ jobs:
             --user ${{ github.repository_owner }} \
             --project ${{ github.event.repository.name }} \
             --no-issues \
-            --exclude-labels "duplicate,question,invalid,wontfix,skip changelog"
+            --exclude-labels "duplicate,question,invalid,wontfix,skip changelog,changelog"
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## 問題

changelog 自動更新ワークフロー (`auto_changelog.yaml`) が、自分の生成した changelog PR (`chore/changelog-*`) のマージでも再発火し、次の changelog PR を無限に作り続けていました。

実例: #234 マージ → #236/#237 生成 → #237 マージ → #239 生成(いずれも自動生成PR)

さらに `--exclude-labels` に `changelog` ラベルが含まれていなかったため、「docs: Update CHANGELOG」PR自身が CHANGELOG.md に11件記載され、常に非空diffとなってPR生成が止まらない状態でした。

## 修正内容

1. マージされたPRの head ブランチが `chore/changelog-*` の場合はジョブをスキップ(通常のPRマージ時のみ実行)
2. `github_changelog_generator` の `--exclude-labels` に `changelog` を追加し、changelog更新PR自身が CHANGELOG に載らないように

## マージ後のクリーンアップ(手動)

- 残留中の自動生成PR #236 / #239 のクローズを推奨します

🤖 Generated with [Claude Code](https://claude.com/claude-code)