### PR TITLE
docs: add FAQ page with CUDA-enabled PyTorch installation guide

### DIFF
--- a/docs/faq.en.md
+++ b/docs/faq.en.md
@@ -1,0 +1,71 @@
+# FAQ
+
+## Q. My GPU (CUDA) is not recognized. How do I install a CUDA-enabled build of PyTorch? {: #cuda-pytorch }
+
+A. PyTorch must be installed as a build that matches your CUDA environment. In particular, the PyTorch version installed by default through the package dependencies may not support CUDA in the following cases:
+
+* When installed from PyPI with `pip install` on Windows (a CPU-only build of PyTorch is installed)
+* When using newer GPUs such as the RTX 50 series (a newer PyTorch build, e.g., one built for CUDA 12.8, may be required)
+
+In these cases, install the dependencies first, then replace only the PyTorch-related packages with the official CUDA builds.
+
+### Installation Steps (using pip)
+
+After installing YomiToku, install the PyTorch packages that match your CUDA version (example: CUDA 12.8).
+
+```bash
+pip install yomitoku
+pip install --upgrade torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+```
+
+### Installation Steps (using uv)
+
+After cloning the repository, install the dependencies.
+
+```bash
+uv sync --extra gpu
+```
+
+Then install the PyTorch packages that match your CUDA version (example: CUDA 12.8).
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    uv pip install --upgrade `
+      torch==2.7.0 `
+      torchvision==0.22.0 `
+      --index-url https://download.pytorch.org/whl/cu128
+    ```
+
+=== "Linux"
+
+    ```bash
+    uv pip install --upgrade \
+      torch==2.7.0 \
+      torchvision==0.22.0 \
+      --index-url https://download.pytorch.org/whl/cu128
+    ```
+
+!!! warning
+    Re-running `uv sync` afterwards will revert PyTorch to the version declared in `pyproject.toml`. In that case, perform the replacement step again.
+
+### Verifying CUDA Availability
+
+After installation, verify that CUDA is recognized with the following command.
+
+```bash
+python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+```
+
+You can confirm that inference is running on the GPU using the following methods:
+
+* Monitor GPU utilization and memory usage with `nvidia-smi` during execution
+* Check CUDA memory allocation with `torch.cuda.memory_allocated()` and similar APIs
+
+!!! note
+    If `device="cuda"` is specified while CUDA is unavailable, YomiToku logs the warning `CUDA is not available. Use CPU instead.` and falls back to running on the CPU. If processing is slower than expected, check the logs for this warning.
+
+### Notes
+
+* Use the latest official NVIDIA driver compatible with your CUDA version and GPU. YomiToku does not pin a specific driver version.
+* YomiToku uses only the standard public APIs of PyTorch / torchvision, and this kind of minor version update is generally compatible. However, since this configuration differs from the versions declared in the package dependencies, we recommend validating with your actual documents and PDFs before production use.

--- a/docs/faq.ja.md
+++ b/docs/faq.ja.md
@@ -1,0 +1,71 @@
+# FAQ
+
+## Q. GPU（CUDA）が認識されません。CUDA に対応した PyTorch のインストール方法を教えてください。 {: #cuda-pytorch }
+
+A. PyTorch はご自身の CUDA 環境に合わせたビルドをインストールする必要があります。特に以下のケースでは、依存関係として標準でインストールされる PyTorch では CUDA が利用できないことがあります。
+
+* Windows で PyPI から `pip install` した場合（CPU 版の PyTorch がインストールされます）
+* RTX 50 シリーズなどの新しい GPU を利用する場合（CUDA 12.8 対応ビルドなど、より新しい PyTorch が必要になることがあります）
+
+この場合、先に依存パッケージを導入した後、PyTorch 関連パッケージのみを公式の CUDA ビルドへ置き換えてください。
+
+### 導入手順（pip を利用する場合）
+
+YomiToku をインストール後、CUDA のバージョンに対応する PyTorch 関連パッケージをインストールします（例: CUDA 12.8）。
+
+```bash
+pip install yomitoku
+pip install --upgrade torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+```
+
+### 導入手順（uv を利用する場合）
+
+リポジトリをクローン後、依存関係をインストールします。
+
+```bash
+uv sync --extra gpu
+```
+
+続いて、CUDA のバージョンに対応する PyTorch 関連パッケージをインストールします（例: CUDA 12.8）。
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    uv pip install --upgrade `
+      torch==2.7.0 `
+      torchvision==0.22.0 `
+      --index-url https://download.pytorch.org/whl/cu128
+    ```
+
+=== "Linux"
+
+    ```bash
+    uv pip install --upgrade \
+      torch==2.7.0 \
+      torchvision==0.22.0 \
+      --index-url https://download.pytorch.org/whl/cu128
+    ```
+
+!!! warning
+    この後に `uv sync` を再実行すると、PyTorch は `pyproject.toml` の宣言バージョンへ戻ります。その場合は置き換え手順を再度実施してください。
+
+### CUDA 認識の確認
+
+導入後、以下のコマンドで CUDA が認識されていることを確認してください。
+
+```bash
+python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+```
+
+推論が GPU 上で実行されていることは、以下の方法で確認できます。
+
+* 実行中に `nvidia-smi` で GPU 使用率・メモリ使用量を確認する
+* `torch.cuda.memory_allocated()` 等で CUDA メモリの確保状況を確認する
+
+!!! note
+    CUDA が利用できない状態で `device="cuda"` を指定した場合、`CUDA is not available. Use CPU instead.` という警告を出力したうえで CPU にフォールバックして実行されます。処理が想定より遅い場合は、ログに本警告が出ていないか確認してください。
+
+### 注意事項
+
+* NVIDIA ドライバは、利用する CUDA バージョンおよび GPU に対応した公式最新版をご利用ください。YomiToku 側で特定バージョンは固定していません。
+* YomiToku は PyTorch / torchvision の一般的な公開 API のみを利用しており、この種のマイナーバージョン更新は通常互換性があります。ただし、依存関係として宣言しているバージョンとは異なる組み合わせとなるため、本番利用の前には実際の文書・PDF での事前検証を推奨します。

--- a/docs/installation.en.md
+++ b/docs/installation.en.md
@@ -2,6 +2,8 @@
 
 This package requires Python 3.10 or later and PyTorch 2.5 or later for execution. PyTorch must be installed according to your CUDA version. In normal mode, the model is optimized for a GPU, and a GPU with at least 8GB of VRAM is recommended. While it can run on a CPU, expect long execution times. In efficient mode, it is designed to provide fast inference even on a CPU.
 
+For how to install a CUDA-enabled build of PyTorch (including on Windows or with newer GPUs such as the RTX 50 series), see the [FAQ](faq.md#cuda-pytorch).
+
 ## from PYPI
 
 ```bash
@@ -30,6 +32,9 @@ name = "pytorch-cuda124"
 url = "https://download.pytorch.org/whl/cu124"
 explicit = true
 ```
+
+!!! note
+    Newer GPUs such as the RTX 50 series may require a newer CUDA-enabled PyTorch build than the declared version. See the [FAQ](faq.md#cuda-pytorch) for the installation steps.
 
 ## Using docker
 

--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -2,6 +2,8 @@
 
 本パッケージは Python3.10+, PyTorch が実行に必要です。PyTorch はご自身の環境に合わせて、インストールが必要です。通常モデルは GPU 向けに最適化されており、デバイスは GPU(> VRAM 8G)を推奨しています。CPU でも動作しますが、実行に時間がかかりますのでご注意ください。軽量モデルは CPU でも高速に推論できます。
 
+CUDA に対応した PyTorch のインストール方法（Windows や RTX 50 シリーズなどの新しい GPU を利用する場合を含む）は [FAQ](faq.md#cuda-pytorch) を参照してください。
+
 ## PYPI からインストール
 
 ```bash
@@ -30,6 +32,9 @@ name = "pytorch-cuda124"
 url = "https://download.pytorch.org/whl/cu124"
 explicit = true
 ```
+
+!!! note
+    RTX 50 シリーズなどの新しい GPU では、宣言バージョンよりも新しい CUDA 対応ビルドの PyTorch が必要となる場合があります。導入手順は [FAQ](faq.md#cuda-pytorch) を参照してください。
 
 ## Docker 環境での実行
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
   - Table Semantic Parser: table_semantic_parser.md
   - Module Output: schemas.md
   - Model Config: configuration.md
+  - FAQ: faq.md
   - Release Note: release_note.md
   - MCP: mcp.md
   - Commercial Use: commercial_use_guideline.md


### PR DESCRIPTION
## Summary

CUDA 対応 PyTorch の導入手順をまとめた FAQ ページ (ja/en) を新規追加し、Installation ページからリンクしました。

- **FAQ (ja/en, 新規)**: 「GPU (CUDA) が認識されない」エントリ (`#cuda-pytorch`)
  - Windows で PyPI からの `pip install` は CPU 版 PyTorch になる点、RTX 50 シリーズなど新しい GPU では cu128 等の新しいビルドが必要になる点を原因として明記
  - pip / uv それぞれで、依存導入後に torch/torchvision のみ公式 CUDA ビルドへ置き換える手順 (Windows PowerShell / Linux のタブ表記)
  - `uv sync` 再実行で宣言バージョンに戻る旨の warning
  - CUDA 認識の確認コマンド、`nvidia-smi` / `torch.cuda.memory_allocated()` による GPU 実行確認
  - CUDA 不可時は `CUDA is not available. Use CPU instead.` 警告付きで CPU フォールバックする挙動 (base.py) の注記
- **Installation (ja/en)**: 冒頭の PyTorch 説明と uv の CUDA インデックス変更セクションに FAQ へのリンクを追加
- **mkdocs.yml**: nav に FAQ を追加 (Model Config と Release Note の間)

## Test plan

- [x] `mkdocs build` がエラーなしで完了 (i18n で ja/en 両方生成)
- [x] 生成サイトで FAQ ページの `#cuda-pytorch` アンカーと Installation からのリンク解決を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)